### PR TITLE
Fix PyInstaller comment in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+#  before PyInstaller builds the exe, so as to inject date/other info into it.
 *.manifest
 *.spec
 


### PR DESCRIPTION
## Summary
- clarify PyInstaller comment in `.gitignore` to mention injecting `info` instead of `infos`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898a4d73ef4832fa02e4635dcdcf3b5